### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/home-assistant.yaml
+++ b/.github/workflows/home-assistant.yaml
@@ -1,5 +1,7 @@
 name: Home Assistant CI
 on: [push, pull_request] # yamllint disable-line rule:truthy
+permissions:
+  contents: read
 jobs:
   yamllint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/aronnebrivio/homeassistant-config/security/code-scanning/6](https://github.com/aronnebrivio/homeassistant-config/security/code-scanning/6)

To fix the issue, we will add a `permissions` key to the workflow. Since the jobs in this workflow primarily involve reading repository contents and running checks, we will set the permissions to `contents: read`. This ensures that the jobs have only the minimal access required to perform their tasks. The `permissions` key will be added at the root level of the workflow to apply to all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
